### PR TITLE
Switch to FLTK for video SAR windowing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build-debug
 /image.bin
 /.vscode
+/gold.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_CXX_STANDARD 17)
 
 find_package(CUDAToolkit REQUIRED)
 find_package(Boost COMPONENTS program_options REQUIRED)
-find_package(GLUT REQUIRED)
-find_package(OpenGL REQUIRED)
-find_package(GLEW REQUIRED)
+set(FLTK_SKIP_OPENGL 1)
+set(FLTK_SKIP_FORMS 1)
+find_package(FLTK REQUIRED)
 
 set(DEFAULT_BUILD_TYPE "Release")
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -48,6 +48,8 @@ set(CPP_SOURCES
     src/fft.cpp
     src/helpers.h
     src/helpers.cpp
+    src/sar_ui.h
+    src/sar_ui.cpp
     src/ser.h
     src/ser.cpp
     src/video_sar.h
@@ -57,4 +59,4 @@ add_executable(sarbp src/main.cpp ${CPP_SOURCES})
 set_target_properties(sarbp PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 set_target_properties(sarbp PROPERTIES CUDA_ARCHITECTURES "86")
 target_include_directories(sarbp PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${Boost_INCLUDE_DIRS})
-target_link_libraries(sarbp kernels ${Boost_LIBRARIES} CUDA::cufft ${GLUT_LIBRARIES} OpenGL::GL OpenGL::GLU GLEW::glew)
+target_link_libraries(sarbp kernels ${Boost_LIBRARIES} CUDA::cufft ${FLTK_LIBRARIES})

--- a/src/common.h
+++ b/src/common.h
@@ -46,6 +46,10 @@ struct VideoParams {
     int image_width{1024};
     // Image height in pixels
     int image_height{1024};
+    // Maximum screen width in pixels
+    int max_screen_width{2048};
+    // Maximum screen height in pixels
+    int max_screen_height{2048};
     // Image field of view (meters)
     float image_field_of_view_m{125.0f};
     // Phase history upsampling factor

--- a/src/cpu_bp.cpp
+++ b/src/cpu_bp.cpp
@@ -10,7 +10,7 @@ void cpu_sar_bp(std::vector<cuComplex> &image, int image_width,
 
     const double dr_inv = 1.0 / dr;
     for (iy = 0; iy < image_height; ++iy) {
-        const double py = (-image_height / 2.0 + 0.5 + iy) * dy;
+        const double py = (image_height / 2.0 - 0.5 - iy) * dy;
         for (ix = 0; ix < image_width; ++ix) {
             cuDoubleComplex accum = make_cuDoubleComplex(0.0, 0.0);
             const double px = (-image_width / 2.0 + 0.5 + ix) * dx;

--- a/src/kernels.h
+++ b/src/kernels.h
@@ -8,7 +8,7 @@
 void FftShiftGpu(cuComplex *data, int num_samples, int num_arrays,
                  cudaStream_t stream);
 
-size_t GetBackprojWorkBufSizeBytes(SarGpuKernel kernel, int num_range_bins);
+size_t GetMaxBackprojWorkBufSizeBytes(int num_range_bins);
 
 void SarBpGpu(cuComplex *image, int image_width, int image_height,
               const cuComplex *range_profiles, uint8_t *bp_workbuf,
@@ -18,9 +18,13 @@ void SarBpGpu(cuComplex *image, int image_width, int image_height,
 
 size_t GetMaxMagnitudeWorkBufSizeBytes(int image_height);
 
-void ComputeMagnitudeImage(uint *dest_image, float *max_magnitude_workbuf,
+void ComputeMagnitudeImage(uint32_t *dest_image, float *max_magnitude_workbuf,
                            const cuComplex *src_image, int image_width,
                            int image_height, float min_normalized_db,
                            cudaStream_t stream);
+
+void ResampleMagnitudeImage(uint32_t *resampled, const uint32_t *src_image,
+                            int resample_width, int resample_height,
+                            int src_width, int src_height, cudaStream_t stream);
 
 #endif /* _KERNELS_H_ */

--- a/src/sar_ui.cpp
+++ b/src/sar_ui.cpp
@@ -1,0 +1,242 @@
+#include "sar_ui.h"
+
+#include "helpers.h"
+
+class SarImageWidget : public Fl_Widget {
+  public:
+    SarImageWidget() = delete;
+    SarImageWidget(int x, int y, int w, int h, const char *label = 0);
+    virtual ~SarImageWidget() {}
+    void UpdateImage(const uint32_t *image, int width, int height);
+    std::pair<int, int> GetImageScreenDimensions();
+
+    void resize(int x, int y, int w, int h);
+
+  protected:
+    void draw();
+
+  private:
+    static const int NUM_WINDOW_BUFFERS = 2;
+    int m_native_width;
+    int m_native_height;
+    int m_screen_width;
+    int m_screen_height;
+    int m_height_offset;
+    int m_active_window_ind{0};
+    std::vector<uint32_t> m_native_image;
+    std::vector<uint32_t> m_resized_image[NUM_WINDOW_BUFFERS];
+    // The active lock covers m_active_window_ind, m_screen_width, and
+    // m_screen_height. These values will typically be updated once a new image
+    // has been written into an inactive buffer.
+    std::mutex m_active_lock;
+    // The pending lock covers updating the native image and inactive
+    // resampled image.
+    std::mutex m_pending_lock;
+
+    void Resample(int screen_width = -1, int screen_height = -1);
+};
+
+SarImageWidget::SarImageWidget(int x, int y, int w, int h, const char *label)
+    : Fl_Widget(x, y, w, h, label), m_native_width(w), m_native_height(h),
+      m_screen_width(w), m_screen_height(h), m_height_offset(y) {
+    m_native_image.resize(m_native_width * m_native_height);
+    memset(m_native_image.data(), 0,
+           sizeof(uint32_t) * m_native_width * m_native_height);
+    for (int i = 0; i < NUM_WINDOW_BUFFERS; i++) {
+        m_resized_image[i].resize(m_screen_width * m_screen_height);
+        memset(m_resized_image[i].data(), 0,
+               sizeof(uint32_t) * m_screen_width * m_screen_height);
+    }
+}
+
+void SarImageWidget::draw() {
+    m_active_lock.lock();
+    fl_draw_image(reinterpret_cast<uint8_t *>(
+                      m_resized_image[m_active_window_ind].data()),
+                  0, m_height_offset, m_screen_width, m_screen_height, 4, 0);
+    m_active_lock.unlock();
+}
+
+void SarImageWidget::resize(int x, int y, int w, int h) {
+    Fl_Widget::resize(x, y, w, h);
+    Resample(w, h);
+}
+
+// Typically, the SAR image will have been resampled to the current
+// window size on the GPU being being pushed to the SarUI class. However,
+// when the window is resized, it may take 1-2 reconstructions before
+// the resampling will be handled on the GPU. This resampler is a fallback
+// for that interim period. If the native image size matches the screen
+// size, it's just a memory copy, but if not, then the native image
+// is resampled via nearest neighbor interpolation to fill the window.
+// The resampling that is done on the GPU is currently bilinear interpolation
+// and thus produces better quality images (at least in the case that the
+// window is larger than the native reconstruction).
+void SarImageWidget::Resample(int screen_width, int screen_height) {
+    m_pending_lock.lock();
+    screen_width = (screen_width >= 0) ? screen_width : m_screen_width;
+    screen_height = (screen_height >= 0) ? screen_height : m_screen_height;
+    const int next_resample_ind =
+        (m_active_window_ind + 1) % NUM_WINDOW_BUFFERS;
+    std::vector<uint32_t> &img = m_resized_image[next_resample_ind];
+    img.resize(screen_width * screen_height);
+    if (screen_width == m_native_width && screen_height == m_native_height) {
+        memcpy(img.data(), m_native_image.data(),
+               sizeof(uint32_t) * m_native_width * m_native_height);
+    } else {
+        std::vector<int> x_native_coord(screen_width);
+        const float width_conv_factor =
+            static_cast<double>(m_native_width) / screen_width;
+        const float height_conv_factor =
+            static_cast<double>(m_native_height) / screen_height;
+        for (int i = 0; i < screen_width; i++) {
+            x_native_coord[i] = static_cast<int>(roundf(i * width_conv_factor));
+        }
+        for (int i = 0; i < screen_height; i++) {
+            const int iy = static_cast<int>(roundf(i * height_conv_factor));
+            for (int j = 0; j < screen_width; j++) {
+                const int ix = x_native_coord[j];
+                img[i * screen_width + j] =
+                    m_native_image[iy * m_native_width + ix];
+            }
+        }
+    }
+    m_active_lock.lock();
+    m_active_window_ind = (m_active_window_ind + 1) % NUM_WINDOW_BUFFERS;
+    m_screen_width = screen_width;
+    m_screen_height = screen_height;
+    m_active_lock.unlock();
+    m_pending_lock.unlock();
+    redraw();
+    Fl::awake();
+}
+
+void SarImageWidget::UpdateImage(const uint32_t *image, int width, int height) {
+    if (width <= 0 || height <= 0) {
+        return;
+    }
+    m_pending_lock.lock();
+    if (static_cast<size_t>(width * height) > m_native_image.size()) {
+        m_native_image.resize(width * height);
+    }
+    memcpy(m_native_image.data(), image, sizeof(uint32_t) * width * height);
+    m_native_width = width;
+    m_native_height = height;
+    m_pending_lock.unlock();
+    Resample();
+}
+
+std::pair<int, int> SarImageWidget::GetImageScreenDimensions() {
+    m_active_lock.lock();
+    const int w = m_screen_width;
+    const int h = m_screen_height;
+    m_active_lock.unlock();
+    return std::make_pair(w, h);
+}
+
+static void kernel_cb(Fl_Widget *widget, void *userdata) {
+    SarUI *ui = reinterpret_cast<SarUI *>(userdata);
+    ui->KernelSelectionCallback(widget);
+}
+
+void SarUI::KernelSelectionCallback(Fl_Widget *widget) {
+    Fl_Choice *choice = reinterpret_cast<Fl_Choice *>(widget);
+    const int kernel_val = (choice->value() - m_kernel_ref_ind) + 1;
+    switch (kernel_val) {
+    case static_cast<int>(SarGpuKernel::DoublePrecision):
+        SetSelectedKernel(SarGpuKernel::DoublePrecision);
+        break;
+    case static_cast<uintptr_t>(SarGpuKernel::MixedPrecision):
+        SetSelectedKernel(SarGpuKernel::MixedPrecision);
+        break;
+    case static_cast<uintptr_t>(SarGpuKernel::SmemRange):
+        SetSelectedKernel(SarGpuKernel::SmemRange);
+        break;
+    case static_cast<uintptr_t>(SarGpuKernel::IncrPhaseLookup):
+        SetSelectedKernel(SarGpuKernel::IncrPhaseLookup);
+        break;
+    case static_cast<uintptr_t>(SarGpuKernel::SinglePrecision):
+        SetSelectedKernel(SarGpuKernel::SinglePrecision);
+        break;
+    default:
+        LOG("Invalid kernel selection %d", kernel_val);
+    }
+}
+
+static void exit_cb(Fl_Widget *, void *userdata) {
+    SarUI *ui = reinterpret_cast<SarUI *>(userdata);
+    ui->Close();
+}
+
+void SarUI::Close() {
+    m_lock.lock();
+    m_stop = true;
+    m_lock.unlock();
+    Fl::awake();
+}
+
+SarUI::SarUI(int width, int height) : m_width(width), m_height(height) {
+    m_window.reset(
+        new Fl_Double_Window(m_width, m_height + m_menu_height, "Video SAR"));
+    const int file_menu_width = 50;
+    const int kernel_menu_offset = 50;
+    const int kernel_menu_width = 200;
+    m_menu_group.reset(new Fl_Group(0, 0, m_width, m_menu_height));
+    m_file_menu.reset(new Fl_Menu_Bar(0, 0, file_menu_width, m_menu_height));
+    m_file_menu->add("&File/E&xit", FL_COMMAND + 'x', exit_cb, this);
+    m_file_menu->box(FL_NO_BOX);
+    m_kernel_menu.reset(new Fl_Choice(file_menu_width + kernel_menu_offset, 0,
+                                      kernel_menu_width, m_menu_height,
+                                      "&Kernel"));
+    m_kernel_ref_ind =
+        m_kernel_menu->add("FP64 (Reference)", 0, kernel_cb, this);
+    m_kernel_menu->add("Mixed Precision (Opt1)", 0, kernel_cb, this);
+    m_kernel_menu->add("Smem Range (Opt2)", 0, kernel_cb, this);
+    m_kernel_menu->add("IncrPhaseLookup (Opt3)", 0, kernel_cb, this);
+    m_kernel_menu->add("SinglePrecision (Opt4)", 0, kernel_cb, this);
+    m_kernel_menu->value(m_kernel_ref_ind);
+    m_menu_group->resizable(nullptr);
+    m_menu_group->end();
+    m_sar_image.reset(new SarImageWidget(0, m_menu_height, m_width, m_height));
+    m_window->resizable(m_sar_image.get());
+    m_window->size_range(width / 2, height / 2, 2048, 2048);
+    m_window->end();
+}
+
+SarUI::~SarUI() {
+    m_file_menu.reset(nullptr);
+    m_kernel_menu.reset(nullptr);
+    m_menu_group.reset(nullptr);
+    m_sar_image.reset(nullptr);
+    m_window.reset(nullptr);
+}
+
+bool SarUI::IsStopping() {
+    std::lock_guard guard(m_lock);
+    return m_stop;
+}
+
+void SarUI::UpdateImage(const uint32_t *pix, int width, int height) {
+    if (IsStopping()) {
+        return;
+    }
+    m_sar_image->UpdateImage(pix, width, height);
+}
+
+std::pair<int, int> SarUI::GetImageScreenDimensions() {
+    return (m_sar_image) ? m_sar_image->GetImageScreenDimensions()
+                         : std::make_pair(0, 0);
+}
+
+void SarUI::StartEventLoop() {
+    Fl::visual(FL_RGB);
+    m_window->show(0, nullptr);
+    Fl::lock();
+    while (Fl::first_window()) {
+        if (IsStopping()) {
+            m_window->hide();
+            break;
+        }
+        Fl::wait();
+    }
+}

--- a/src/sar_ui.h
+++ b/src/sar_ui.h
@@ -1,0 +1,72 @@
+#ifndef _SAR_UI_H_
+#define _SAR_UI_H_
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include "common.h"
+
+#include <FL/Fl.H>
+#include <FL/Fl_Choice.H>
+#include <FL/Fl_Double_Window.H>
+#include <FL/Fl_Group.H>
+#include <FL/Fl_Image.H>
+#include <FL/Fl_Menu_Bar.H>
+#include <FL/Fl_Menu_Item.H>
+#include <FL/Fl_Widget.H>
+#include <FL/fl_draw.H>
+// The X.h header that is ultimately included via FLTK dependencies
+// defines Success as a macro with value 0, which conflicts with
+// other uses of Success. We do not use the X.h macro explicitly,
+// or any other macro named Success, so undefine it here.
+#undef Success
+
+// Forward declaration
+class SarImageWidget;
+
+class SarUI {
+  public:
+    SarUI(int width, int height);
+    ~SarUI();
+    int GetWidth() { return m_width; }
+    int GetHeight() { return m_height; }
+
+    SarGpuKernel GetSelectedKernel() {
+        std::lock_guard<std::mutex> guard(m_lock);
+        return m_kernel;
+    }
+
+    void SetSelectedKernel(SarGpuKernel kernel) {
+        m_lock.lock();
+        m_kernel = kernel;
+        m_lock.unlock();
+    }
+
+    void UpdateImage(const uint32_t *pix, int width, int height);
+    void StartEventLoop();
+    void Close();
+    bool IsStopping();
+    std::pair<int, int> GetImageScreenDimensions();
+
+    void KernelSelectionCallback(Fl_Widget *widget);
+
+  private:
+    int m_width;
+    int m_height;
+    static const int m_menu_height{30};
+    SarGpuKernel m_kernel{SarGpuKernel::DoublePrecision};
+    int m_kernel_ref_ind{0};
+    bool m_stop{false};
+    std::mutex m_lock;
+
+    std::unique_ptr<Fl_Menu_Bar> m_file_menu;
+    std::unique_ptr<Fl_Choice> m_kernel_menu;
+    std::unique_ptr<Fl_Group> m_menu_group;
+    std::unique_ptr<SarImageWidget> m_sar_image;
+    std::unique_ptr<Fl_Double_Window> m_window;
+};
+
+#endif // _SAR_UI_H_

--- a/src/video_sar.cpp
+++ b/src/video_sar.cpp
@@ -1,339 +1,19 @@
 #include <cstring>
 #include <filesystem>
 #include <mutex>
+#include <vector>
 
 #include <cuda_runtime.h>
-
-// clang-format off
-// The glew header must be processed before gl.h and glext.h
-#include <GL/glew.h>
-#include <GL/gl.h>
-#include <GL/glext.h>
-#include <GL/freeglut.h>
-// clang-format on
-
-#include <cuda_gl_interop.h>
 
 #include "data_reader.h"
 #include "helpers.h"
 #include "kernels.h"
+#include "video_sar.h"
 
 namespace fs = std::filesystem;
 
-static struct {
-    Gotcha::DataBlock data_set;
-
-    GLuint pbo{0};
-    GLuint tex{0};
-    struct cudaGraphicsResource *cuda_pbo_resource{nullptr};
-
-    // Device buffers
-    cuComplex *dev_range_profiles{nullptr};
-    cuComplex *dev_image{nullptr};
-    float3 *dev_ant_pos{nullptr};
-    float *dev_max_magnitude_workbuf{nullptr};
-    uint8_t *dev_bp_workbuf{nullptr};
-
-    // Host pinned buffers
-    cuComplex *phase_history{nullptr};
-    cuComplex *image{nullptr};
-    cuComplex *ant_pos{nullptr};
-
-    cudaStream_t stream{0};
-    cufftHandle fft_plan{0};
-
-    VideoParams params;
-
-    int num_upsampled_bins{0};
-    int start_az_next_image{0};
-
-    // The lock is only needed for user-adjustable parameters like
-    // the number of azimuth degrees per image.
-    std::mutex m_lock;
-
-    int adjustAzimuthDegreesPerImage(int adj) {
-        std::lock_guard<std::mutex> guard(m_lock);
-        params.az_degrees_per_image =
-            std::max(0, std::min(params.az_degrees_per_image + adj, 360));
-        return params.az_degrees_per_image;
-    }
-
-    int getAzimuthDegreesPerImage() {
-        std::lock_guard<std::mutex> guard(m_lock);
-        return params.az_degrees_per_image;
-    }
-} s_state;
-
-static void initCuda() {
-    const Gotcha::DataRequest request = {
-        .first_az = 1,
-        .last_az = 360,
-        .pass = s_state.params.pass,
-        .polarization = Gotcha::Polarization::HH,
-    };
-
-    Gotcha::Reader reader(s_state.params.gotcha_dir);
-    const SarReturnCode rc = reader.ReadDataSet(s_state.data_set, request);
-    if (rc != SarReturnCode::Success) {
-        LOG_ERR("Failed to read data set: %s", GetSarReturnCodeString(rc));
-        exit(EXIT_FAILURE);
-    }
-
-    s_state.num_upsampled_bins =
-        static_cast<int>(pow(2, ceil(log(s_state.params.range_upsample_factor *
-                                         s_state.data_set.num_freq) /
-                                     log(2))));
-
-    const int n_pulses = s_state.data_set.num_pulses;
-    const int n_freq = s_state.data_set.num_freq;
-    const int nx = s_state.params.image_width;
-    const int ny = s_state.params.image_height;
-
-    LOG("Loaded %d pulses", n_pulses);
-
-    cudaChecked(
-        cudaMalloc((void **)&s_state.dev_range_profiles,
-                   n_pulses * s_state.num_upsampled_bins * sizeof(cuComplex)));
-    cudaChecked(
-        cudaMalloc((void **)&s_state.dev_image, nx * ny * sizeof(cuComplex)));
-    cudaChecked(
-        cudaMalloc((void **)&s_state.dev_ant_pos, sizeof(float3) * n_pulses));
-    const size_t mag_workbuf_size_bytes = GetMaxMagnitudeWorkBufSizeBytes(ny);
-    cudaChecked(cudaMalloc((void **)&s_state.dev_max_magnitude_workbuf,
-                           mag_workbuf_size_bytes));
-
-    const size_t bp_workbuf_bytes = GetBackprojWorkBufSizeBytes(
-        s_state.params.kernel, s_state.num_upsampled_bins);
-    if (bp_workbuf_bytes > 0) {
-        cudaChecked(
-            cudaMalloc((void **)&s_state.dev_bp_workbuf, bp_workbuf_bytes));
-    }
-
-    cudaChecked(cudaMallocHost((void **)&s_state.phase_history,
-                               n_pulses * n_freq * sizeof(cuComplex)));
-    cudaChecked(
-        cudaMallocHost((void **)&s_state.image, nx * ny * sizeof(cuComplex)));
-    cudaChecked(cudaMallocHost((void **)&s_state.ant_pos,
-                               s_state.data_set.num_pulses * sizeof(float3)));
-
-    memcpy(s_state.phase_history, &s_state.data_set.phase_history[0],
-           sizeof(cuComplex) * n_pulses * n_freq);
-    memcpy(s_state.ant_pos, &s_state.data_set.ant_pos[0],
-           sizeof(float3) * n_pulses);
-
-    cudaChecked(cudaStreamCreate(&s_state.stream));
-    cufftChecked(cufftPlan1d(&s_state.fft_plan, s_state.num_upsampled_bins,
-                             CUFFT_C2C, n_pulses));
-    cufftChecked(cufftSetStream(s_state.fft_plan, s_state.stream));
-}
-
-static int isGLVersionSupported(unsigned reqMajor, unsigned reqMinor) {
-#if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-    if (glewInit() != GLEW_OK) {
-        std::cerr << "glewInit() failed!" << std::endl;
-        return 0;
-    }
-#endif
-    const auto gl_version = glGetString(GL_VERSION);
-    LOG("gl_version='%s'", (const char *)gl_version);
-    std::string version((const char *)gl_version);
-    std::stringstream stream(version);
-    unsigned major, minor;
-    char dot;
-
-    stream >> major >> dot >> minor;
-
-    return major > reqMajor || (major == reqMajor && minor >= reqMinor);
-}
-
-static void cleanup() {
-    if (s_state.pbo) {
-        cudaGraphicsUnregisterResource(s_state.cuda_pbo_resource);
-        glDeleteBuffersARB(1, &s_state.pbo);
-        s_state.pbo = 0;
-        glDeleteTextures(1, &s_state.tex);
-        s_state.tex = 0;
-    }
-
-    cudaStreamDestroy(s_state.stream);
-    cufftDestroy(s_state.fft_plan);
-    cudaFreeHost(s_state.ant_pos);
-    cudaFreeHost(s_state.image);
-    cudaFreeHost(s_state.phase_history);
-    cudaFree(s_state.dev_max_magnitude_workbuf);
-    cudaFree(s_state.dev_ant_pos);
-    if (s_state.dev_bp_workbuf) {
-        cudaFree(s_state.dev_bp_workbuf);
-    }
-    cudaFree(s_state.dev_image);
-    cudaFree(s_state.dev_range_profiles);
-    s_state.data_set.Reset();
-}
-
-static void render() {
-    static bool have_copied_data = false;
-
-    const int n_pulses = s_state.data_set.num_pulses;
-    const int n_freq = s_state.data_set.num_freq;
-    const int az_degrees_per_image = s_state.getAzimuthDegreesPerImage();
-
-    const int n_pulses_per_az_deg = static_cast<int>(roundf(n_pulses / 360.0f));
-    const int first_pulse_this_img =
-        s_state.start_az_next_image * n_pulses_per_az_deg;
-    const int n_pulses_this_img = n_pulses_per_az_deg * az_degrees_per_image;
-
-    const int nx = s_state.params.image_width;
-    const int ny = s_state.params.image_height;
-
-    // map PBO to get CUDA device pointer
-    uint *dev_output;
-    cudaChecked(cudaGraphicsMapResources(1, &s_state.cuda_pbo_resource, 0));
-    size_t num_bytes;
-    cudaChecked(cudaGraphicsResourceGetMappedPointer(
-        (void **)&dev_output, &num_bytes, s_state.cuda_pbo_resource));
-
-    if (!have_copied_data) {
-        cudaChecked(cudaMemcpyAsync(s_state.dev_ant_pos, s_state.ant_pos,
-                                    sizeof(float3) * n_pulses,
-                                    cudaMemcpyHostToDevice, s_state.stream));
-        cudaChecked(cudaMemcpy2DAsync(
-            s_state.dev_range_profiles,
-            sizeof(cufftComplex) * s_state.num_upsampled_bins,
-            s_state.phase_history, sizeof(cufftComplex) * n_freq,
-            sizeof(cufftComplex) * n_freq, n_pulses, cudaMemcpyHostToDevice,
-            s_state.stream));
-        cudaChecked(cudaMemset2DAsync(
-            s_state.dev_range_profiles + n_freq,
-            sizeof(cuComplex) * s_state.num_upsampled_bins, 0,
-            sizeof(cuComplex) * (s_state.num_upsampled_bins - n_freq), n_pulses,
-            s_state.stream));
-        cufftChecked(cufftExecC2C(s_state.fft_plan, s_state.dev_range_profiles,
-                                  s_state.dev_range_profiles, CUFFT_INVERSE));
-        FftShiftGpu(s_state.dev_range_profiles, s_state.num_upsampled_bins,
-                    n_pulses, s_state.stream);
-        have_copied_data = true;
-    }
-
-    cudaChecked(cudaMemsetAsync(s_state.dev_image, 0,
-                                sizeof(cuComplex) * nx * ny, s_state.stream));
-
-    const double c = SPEED_OF_LIGHT_M_PER_SEC;
-    const float maxWr =
-        static_cast<float>(c / (2.0 * s_state.data_set.del_freq));
-    const float image_field_of_view_m = 150.0f;
-    const float dx = image_field_of_view_m / nx;
-    const float dy = image_field_of_view_m / ny;
-    const float dR = maxWr / s_state.num_upsampled_bins;
-
-    if (first_pulse_this_img + n_pulses_this_img <= n_pulses) {
-        SarBpGpu(s_state.dev_image, nx, ny,
-                 s_state.dev_range_profiles +
-                     first_pulse_this_img * s_state.num_upsampled_bins,
-                 s_state.dev_bp_workbuf, s_state.num_upsampled_bins,
-                 n_pulses_this_img, s_state.dev_ant_pos + first_pulse_this_img,
-                 s_state.data_set.min_freq, dR, dx, dy, 0.0f,
-                 s_state.params.kernel, s_state.stream);
-    } else {
-        SarBpGpu(s_state.dev_image, nx, ny,
-                 s_state.dev_range_profiles +
-                     first_pulse_this_img * s_state.num_upsampled_bins,
-                 s_state.dev_bp_workbuf, s_state.num_upsampled_bins,
-                 n_pulses - first_pulse_this_img,
-                 s_state.dev_ant_pos + first_pulse_this_img,
-                 s_state.data_set.min_freq, dR, dx, dy, 0.0f,
-                 s_state.params.kernel, s_state.stream);
-        const int pulses_remaining =
-            n_pulses_this_img - (n_pulses - first_pulse_this_img);
-        SarBpGpu(s_state.dev_image, nx, ny, s_state.dev_range_profiles,
-                 s_state.dev_bp_workbuf, s_state.num_upsampled_bins,
-                 pulses_remaining, s_state.dev_ant_pos,
-                 s_state.data_set.min_freq, dR, dx, dy, 0.0f,
-                 s_state.params.kernel, s_state.stream);
-    }
-
-    const float min_normalized_db = -70;
-    ComputeMagnitudeImage(dev_output, s_state.dev_max_magnitude_workbuf,
-                          s_state.dev_image, nx, ny, min_normalized_db,
-                          s_state.stream);
-
-    cudaChecked(cudaStreamSynchronize(s_state.stream));
-
-    cudaChecked(cudaGraphicsUnmapResources(1, &s_state.cuda_pbo_resource, 0));
-
-    cudaChecked(cudaDeviceSynchronize());
-
-    s_state.start_az_next_image =
-        (s_state.start_az_next_image + az_degrees_per_image) % 360;
-}
-
-static void display() {
-    render();
-
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-    glDisable(GL_DEPTH_TEST);
-
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-
-    // copy from pbo to texture
-    glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, s_state.pbo);
-    glBindTexture(GL_TEXTURE_2D, s_state.tex);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, s_state.params.image_width,
-                    s_state.params.image_height, GL_RGBA, GL_UNSIGNED_BYTE, 0);
-    glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, 0);
-
-    // draw textured quad
-    glEnable(GL_TEXTURE_2D);
-    glBegin(GL_QUADS);
-    glTexCoord2f(0, 0);
-    glVertex2f(0, 0);
-    glTexCoord2f(1, 0);
-    glVertex2f(1, 0);
-    glTexCoord2f(1, 1);
-    glVertex2f(1, 1);
-    glTexCoord2f(0, 1);
-    glVertex2f(0, 1);
-    glEnd();
-
-    glDisable(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, 0);
-
-    glutSwapBuffers();
-    glutReportErrors();
-}
-
-static void idle() { glutPostRedisplay(); }
-
-static void keyboard(unsigned char key, int, int) {
-    switch (key) {
-    case '-': {
-        const int az = s_state.adjustAzimuthDegreesPerImage(-5);
-        LOG("Using %d azimuth degrees per image\n", az);
-    } break;
-    case '+': {
-        const int az = s_state.adjustAzimuthDegreesPerImage(5);
-        LOG("Using %d azimuth degrees per image\n", az);
-    } break;
-    case 27:
-        // Escape key
-        exit(EXIT_SUCCESS);
-        break;
-    }
-    glutPostRedisplay();
-}
-
-static void mouse(int, int, int, int) { glutPostRedisplay(); }
-
-static void reshape(int w, int h) {
-    glViewport(0, 0, w, h);
-    glutPostRedisplay();
-}
-
-void runVideo(const VideoParams &params, int argc, char **argv, int device_id) {
-#if defined(__linux__)
-    setenv("DISPLAY", ":0", 0);
-#endif
-
+VideoSar::VideoSar(const VideoParams &params, int device_id, SarUI &ui)
+    : m_ui(ui), m_params(params) {
     int num_devices = -1;
     cudaChecked(cudaGetDeviceCount(&num_devices));
     if (device_id < 0 || device_id >= num_devices) {
@@ -344,65 +24,196 @@ void runVideo(const VideoParams &params, int argc, char **argv, int device_id) {
 
     cudaChecked(cudaSetDevice(device_id));
 
-    s_state.params = params;
-    const int window_width = 768;
-    const int window_height = 768;
-    glutInit(&argc, argv);
-    glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE);
-    glutInitWindowSize(window_width, window_height);
-    glutCreateWindow("Video SAR");
-    glewInit();
+    InitCudaBuffers();
+}
 
-    if (!isGLVersionSupported(2, 0)) {
-        LOG("Missing necessary GL support");
+void VideoSar::FreeCudaBuffers() {
+    cudaStreamDestroy(m_stream);
+    cufftDestroy(m_fft_plan);
+    cudaFreeHost(m_pinned.ant_pos);
+    cudaFreeHost(m_pinned.image);
+    cudaFreeHost(m_pinned.phase_history);
+    cudaFreeHost(m_pinned.display_image);
+    cudaFree(m_dev.max_magnitude_workbuf);
+    cudaFree(m_dev.ant_pos);
+    if (m_dev.bp_workbuf) {
+        cudaFree(m_dev.bp_workbuf);
+    }
+    cudaFree(m_dev.image);
+    cudaFree(m_dev.magnitude_image);
+    cudaFree(m_dev.resampled_magnitude_image);
+    cudaFree(m_dev.range_profiles);
+}
+
+void VideoSar::InitCudaBuffers() {
+    const int pass = 1;
+    const Gotcha::DataRequest request = {
+        .first_az = 1,
+        .last_az = 360,
+        .pass = pass,
+        .polarization = Gotcha::Polarization::HH,
+    };
+
+    Gotcha::Reader reader(m_params.gotcha_dir);
+    const SarReturnCode rc = reader.ReadDataSet(m_data_set, request);
+    if (rc != SarReturnCode::Success) {
+        LOG_ERR("Failed to read data set: %s", GetSarReturnCodeString(rc));
         exit(EXIT_FAILURE);
     }
 
-    glutDisplayFunc(display);
-    glutKeyboardFunc(keyboard);
-    glutMouseFunc(mouse);
-    glutReshapeFunc(reshape);
-    glutIdleFunc(idle);
-    glutCloseFunc(cleanup);
+    m_num_upsampled_bins = static_cast<int>(
+        pow(2, ceil(log(m_params.range_upsample_factor * m_data_set.num_freq) /
+                    log(2))));
 
-    // default initialization
-    glClearColor(0.0, 0.0, 0.0, 1.0);
-    glDisable(GL_DEPTH_TEST);
+    const int n_pulses = m_data_set.num_pulses;
+    const int n_freq = m_data_set.num_freq;
+    const int nx = m_params.image_width;
+    const int ny = m_params.image_height;
+    const int max_nx = m_params.max_screen_width;
+    const int max_ny = m_params.max_screen_height;
 
-    glViewport(0, 0, window_width, window_height);
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0.0, 1.0, 0.0, 1.0, 0.0, 1.0);
+    LOG("Loaded %d pulses", n_pulses);
 
-    initCuda();
+    cudaChecked(
+        cudaMalloc((void **)&m_dev.range_profiles,
+                   n_pulses * m_num_upsampled_bins * sizeof(cuComplex)));
+    cudaChecked(cudaMalloc((void **)&m_dev.image, nx * ny * sizeof(cuComplex)));
+    cudaChecked(cudaMalloc((void **)&m_dev.ant_pos, sizeof(float3) * n_pulses));
+    const size_t mag_workbuf_size_bytes = GetMaxMagnitudeWorkBufSizeBytes(ny);
+    cudaChecked(cudaMalloc((void **)&m_dev.max_magnitude_workbuf,
+                           mag_workbuf_size_bytes));
+    cudaChecked(cudaMalloc((void **)&m_dev.magnitude_image,
+                           sizeof(uint32_t) * nx * ny));
+    cudaChecked(cudaMalloc((void **)&m_dev.resampled_magnitude_image,
+                           sizeof(uint32_t) * max_nx * max_ny));
+    const size_t bp_workbuf_bytes =
+        GetMaxBackprojWorkBufSizeBytes(m_num_upsampled_bins);
+    if (bp_workbuf_bytes > 0) {
+        cudaChecked(cudaMalloc((void **)&m_dev.bp_workbuf, bp_workbuf_bytes));
+    }
 
-    const int nx = s_state.params.image_width;
-    const int ny = s_state.params.image_height;
+    cudaChecked(cudaMallocHost((void **)&m_pinned.phase_history,
+                               n_pulses * n_freq * sizeof(cuComplex)));
+    cudaChecked(
+        cudaMallocHost((void **)&m_pinned.image, nx * ny * sizeof(cuComplex)));
+    cudaChecked(cudaMallocHost((void **)&m_pinned.ant_pos,
+                               m_data_set.num_pulses * sizeof(float3)));
+    cudaChecked(cudaMallocHost((void **)&m_pinned.display_image,
+                               sizeof(uint32_t) * max_nx * max_ny));
 
-    // create pixel buffer object for display
-    glGenBuffersARB(1, &s_state.pbo);
-    glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, s_state.pbo);
-    glBufferDataARB(GL_PIXEL_UNPACK_BUFFER_ARB, nx * ny * sizeof(GLubyte) * 4,
-                    0, GL_STREAM_DRAW_ARB);
-    glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, 0);
+    memcpy(m_pinned.phase_history, &m_data_set.phase_history[0],
+           sizeof(cuComplex) * n_pulses * n_freq);
+    memcpy(m_pinned.ant_pos, &m_data_set.ant_pos[0], sizeof(float3) * n_pulses);
 
-    // register this buffer object with CUDA
-    cudaChecked(cudaGraphicsGLRegisterBuffer(&s_state.cuda_pbo_resource,
-                                             s_state.pbo,
-                                             cudaGraphicsMapFlagsWriteDiscard));
+    cudaChecked(cudaStreamCreate(&m_stream));
+    cufftChecked(
+        cufftPlan1d(&m_fft_plan, m_num_upsampled_bins, CUFFT_C2C, n_pulses));
+    cufftChecked(cufftSetStream(m_fft_plan, m_stream));
+}
 
-    glGenTextures(1, &s_state.tex);
-    glBindTexture(GL_TEXTURE_2D, s_state.tex);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, nx, ny, 0, GL_RGBA,
-                 GL_UNSIGNED_BYTE, NULL);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glBindTexture(GL_TEXTURE_2D, 0);
+void VideoSar::Render(int screen_width, int screen_height) {
+    static bool have_copied_data = false;
 
-    glutMainLoop();
+    const int n_pulses = m_data_set.num_pulses;
+    const int n_freq = m_data_set.num_freq;
+    const int az_degrees_per_image = m_params.az_degrees_per_image;
 
-    const GLenum gl_err = glGetError();
-    if (gl_err != GL_NO_ERROR) {
-        LOG_ERR("GL error %d", gl_err);
+    const int n_pulses_per_az_deg = static_cast<int>(roundf(n_pulses / 360.0f));
+    const int first_pulse_this_img =
+        m_start_az_next_image * n_pulses_per_az_deg;
+    const int n_pulses_this_img = n_pulses_per_az_deg * az_degrees_per_image;
+
+    const int nx = m_params.image_width;
+    const int ny = m_params.image_height;
+
+    if (!have_copied_data) {
+        cudaChecked(cudaMemcpyAsync(m_dev.ant_pos, m_pinned.ant_pos,
+                                    sizeof(float3) * n_pulses,
+                                    cudaMemcpyHostToDevice, m_stream));
+        cudaChecked(cudaMemcpy2DAsync(
+            m_dev.range_profiles, sizeof(cufftComplex) * m_num_upsampled_bins,
+            m_pinned.phase_history, sizeof(cufftComplex) * n_freq,
+            sizeof(cufftComplex) * n_freq, n_pulses, cudaMemcpyHostToDevice,
+            m_stream));
+        cudaChecked(cudaMemset2DAsync(
+            m_dev.range_profiles + n_freq,
+            sizeof(cuComplex) * m_num_upsampled_bins, 0,
+            sizeof(cuComplex) * (m_num_upsampled_bins - n_freq), n_pulses,
+            m_stream));
+        cufftChecked(cufftExecC2C(m_fft_plan, m_dev.range_profiles,
+                                  m_dev.range_profiles, CUFFT_INVERSE));
+        FftShiftGpu(m_dev.range_profiles, m_num_upsampled_bins, n_pulses,
+                    m_stream);
+        have_copied_data = true;
+    }
+
+    cudaChecked(
+        cudaMemsetAsync(m_dev.image, 0, sizeof(cuComplex) * nx * ny, m_stream));
+
+    const double c = SPEED_OF_LIGHT_M_PER_SEC;
+    const float maxWr = static_cast<float>(c / (2.0 * m_data_set.del_freq));
+    const float image_field_of_view_m = 150.0f;
+    const float dx = image_field_of_view_m / nx;
+    const float dy = image_field_of_view_m / ny;
+    const float dR = maxWr / m_num_upsampled_bins;
+
+    if (first_pulse_this_img + n_pulses_this_img <= n_pulses) {
+        SarBpGpu(m_dev.image, nx, ny,
+                 m_dev.range_profiles +
+                     first_pulse_this_img * m_num_upsampled_bins,
+                 m_dev.bp_workbuf, m_num_upsampled_bins, n_pulses_this_img,
+                 m_dev.ant_pos + first_pulse_this_img, m_data_set.min_freq, dR,
+                 dx, dy, 0.0f, m_params.kernel, m_stream);
+    } else {
+        SarBpGpu(m_dev.image, nx, ny,
+                 m_dev.range_profiles +
+                     first_pulse_this_img * m_num_upsampled_bins,
+                 m_dev.bp_workbuf, m_num_upsampled_bins,
+                 n_pulses - first_pulse_this_img,
+                 m_dev.ant_pos + first_pulse_this_img, m_data_set.min_freq, dR,
+                 dx, dy, 0.0f, m_params.kernel, m_stream);
+        const int pulses_remaining =
+            n_pulses_this_img - (n_pulses - first_pulse_this_img);
+        SarBpGpu(m_dev.image, nx, ny, m_dev.range_profiles, m_dev.bp_workbuf,
+                 m_num_upsampled_bins, pulses_remaining, m_dev.ant_pos,
+                 m_data_set.min_freq, dR, dx, dy, 0.0f, m_params.kernel,
+                 m_stream);
+    }
+
+    const float min_normalized_db = -70;
+    ComputeMagnitudeImage(m_dev.magnitude_image, m_dev.max_magnitude_workbuf,
+                          m_dev.image, nx, ny, min_normalized_db, m_stream);
+
+    ResampleMagnitudeImage(m_dev.resampled_magnitude_image,
+                           m_dev.magnitude_image, screen_width, screen_height,
+                           nx, ny, m_stream);
+
+    cudaChecked(cudaMemcpyAsync(m_pinned.display_image,
+                                m_dev.resampled_magnitude_image,
+                                sizeof(uint32_t) * screen_width * screen_height,
+                                cudaMemcpyDeviceToHost, m_stream));
+
+    cudaChecked(cudaStreamSynchronize(m_stream));
+
+    cudaChecked(cudaDeviceSynchronize());
+
+    m_start_az_next_image =
+        (m_start_az_next_image + az_degrees_per_image) % 360;
+}
+
+void VideoSar::Run() {
+    while (1) {
+        if (m_stop) {
+            break;
+        }
+        m_params.kernel = m_ui.GetSelectedKernel();
+        std::pair<int, int> wh = m_ui.GetImageScreenDimensions();
+        Render(wh.first, wh.second);
+        if (m_stop) {
+            break;
+        }
+        m_ui.UpdateImage(m_pinned.display_image, wh.first, wh.second);
     }
 }
+
+void VideoSar::Stop() { m_stop = true; }

--- a/src/video_sar.h
+++ b/src/video_sar.h
@@ -3,8 +3,59 @@
 
 #include <filesystem>
 
-#include "common.h"
+#include <cuda_runtime.h>
 
-void runVideo(const VideoParams &params, int argc, char **argv, int device_id);
+#include "common.h"
+#include "data_reader.h"
+#include "sar_ui.h"
+
+class VideoSar {
+  public:
+    VideoSar(const VideoParams &params, int device_id, SarUI &ui);
+    ~VideoSar() {
+        FreeCudaBuffers();
+        m_data_set.Reset();
+    }
+
+    void Run();
+    void Stop();
+
+  private:
+    SarUI &m_ui;
+    SarGpuKernel m_kernel;
+    VideoParams m_params;
+    Gotcha::DataBlock m_data_set;
+
+    int m_num_upsampled_bins{0};
+    int m_start_az_next_image{0};
+
+    bool m_stop{false};
+
+    // Device buffers
+    struct {
+        cuComplex *range_profiles{nullptr};
+        cuComplex *image{nullptr};
+        float3 *ant_pos{nullptr};
+        float *max_magnitude_workbuf{nullptr};
+        uint8_t *bp_workbuf{nullptr};
+        uint32_t *magnitude_image{nullptr};
+        uint32_t *resampled_magnitude_image{nullptr};
+    } m_dev;
+
+    // Host pinned buffers
+    struct {
+        cuComplex *phase_history{nullptr};
+        cuComplex *image{nullptr};
+        cuComplex *ant_pos{nullptr};
+        uint32_t *display_image{nullptr};
+    } m_pinned;
+
+    cudaStream_t m_stream;
+    cufftHandle m_fft_plan;
+
+    void InitCudaBuffers();
+    void FreeCudaBuffers();
+    void Render(int screen_width, int screen_height);
+};
 
 #endif // _VIDEO_SAR_


### PR DESCRIPTION
FLTK supports pulldown menus and this version adds a pulldown menu to select the running kernel. Future reconstructions then use the new kernel, allowing for fast visualization of the performance and image quality.

Signed-off-by: Thomas Benson <tbensongit@gmail.com>