### PR TITLE
Introduce Newton-Raphson and Smem-Range separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,25 +82,27 @@ The optimizations included thus far are a subset of those presented in the follo
 
 https://on-demand.gputechconf.com/gtc/2013/presentations/S3274-Synthetic-Aperture-Radar-Backprojection.pdf
 
-There are currently five kernels (i.e. `--kern 1` through `--kern 5`). Briefly, the kernels are as follows:
+There are currently six kernels (i.e. `--kern 1` through `--kern 6`). Briefly, the kernels are as follows:
 
 - 1 - Double precision
 - 2 - Mixed precision
-- 3 - Pre-compute some ranges (in FP64) and store in shared memory. These PF64 computations then do not need to be repeated by each thread.
-- 4 - Incremental phase calculations to reduce the number of FP64 sine/cosine calculations. Newton-Raphson iterations instead of FP64 `sqrt()`.
-- 5 - Single precision
+- 3 - Incremental phase calculations to reduce the number of FP64 sine/cosine calculations
+- 4 - Newton-Raphson iterations instead of FP64 `sqrt()`.
+- 5 - Pre-compute some FP64 range calculations in shared memory to avoid redundant FP64 calculations in threads
+- 6 - Single precision
 
 The performance metric computed by the code is giga backprojections per second. A single backprojection includes the calculations to accumulate the contributions from a single pixel in a single pulse. With an N by N image and P pulses, there are thus `N*N*P` total backprojection operations.
 
 | Kernel  | SER (dB) | Giga Backprojections Per Second |
 | ------------- | ------------- | ------------- |
-| 1 (FP64) | 124.64 | 1.32 |
-| 2 (Mixed) | 81.10 | 1.67 |
-| 3 (smem pre-computations) | 80.96 | 2.55 |
-| 4 (Newton-Raphson + incr. phase calcs) | 82.05 | 5.35 |
-| 5 (single precision) | 13.99 | 69.58
+| 1 (FP64) | 124.70 | 1.63 |
+| 2 (Mixed) | 79.78 | 2.22 |
+| 3 (Incr Phase Calcs) | 82.42 | 3.91 |
+| 4 (Newton-Raphson) | 82.18 | 4.56 |
+| 5 (Smem Range Calcs) | 82.16 | 5.37 |
+| 6 (Single Precision) | 13.86 | 69.58
 
-The RTX 3060 has 1/64th double precision throughput and we can see a ~52x difference between the FP64 and FP32 implementations. However, the SER value for the single precision is likely too low for many tasks, although it is visually still reasonable. The currently implemented optimizations close the performance gap between a version with high accuracy and the FP32 version to about 13x.
+The RTX 3060 has 1/64th double precision throughput and we can see a ~43x difference between the FP64 and FP32 implementations. However, the SER value for the single precision implementation is likely too low for tasks that utilize the phase information of the pixels, although it is visually still reasonable if only using the magnitude image. The currently implemented optimizations close the performance gap between a version with high accuracy and the FP32 version to about 13x.
 
 # Potential Future Work
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -19,10 +19,12 @@ SarGpuKernel IntToSarGpuKernel(int kernel) {
         return SarGpuKernel::DoublePrecision;
     case static_cast<int>(SarGpuKernel::MixedPrecision):
         return SarGpuKernel::MixedPrecision;
-    case static_cast<int>(SarGpuKernel::SmemRange):
-        return SarGpuKernel::SmemRange;
     case static_cast<int>(SarGpuKernel::IncrPhaseLookup):
         return SarGpuKernel::IncrPhaseLookup;
+    case static_cast<int>(SarGpuKernel::NewtonRaphsonTwoIter):
+        return SarGpuKernel::NewtonRaphsonTwoIter;
+    case static_cast<int>(SarGpuKernel::IncrRangeSmem):
+        return SarGpuKernel::IncrRangeSmem;
     case static_cast<int>(SarGpuKernel::SinglePrecision):
         return SarGpuKernel::SinglePrecision;
     default:

--- a/src/common.h
+++ b/src/common.h
@@ -9,8 +9,9 @@ enum class SarGpuKernel {
     Invalid = 0,
     DoublePrecision,
     MixedPrecision,
-    SmemRange,
     IncrPhaseLookup,
+    NewtonRaphsonTwoIter,
+    IncrRangeSmem,
     SinglePrecision
 };
 

--- a/src/kernels.h
+++ b/src/kernels.h
@@ -10,8 +10,13 @@ void FftShiftGpu(cuComplex *data, int num_samples, int num_arrays,
 
 size_t GetMaxBackprojWorkBufSizeBytes(int num_range_bins);
 
+void ComputeRangeToCenterWrapper(double *dev_range_to_center,
+                                 const float3 *dev_ant_pos, int num_pulses,
+                                 cudaStream_t stream);
+
 void SarBpGpuWrapper(cuComplex *image, int image_width, int image_height,
-                     const cuComplex *range_profiles, uint8_t *bp_workbuf,
+                     const cuComplex *range_profiles,
+                     const double *range_to_center, uint8_t *bp_workbuf,
                      int num_range_bins, int num_pulses, const float3 *ant_pos,
                      double freq_min, double dr, double dx, double dy,
                      double z0, SarGpuKernel selected_kernel,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,7 +144,7 @@ static void runGpu(std::vector<cuComplex> &image, const ReconParams &params,
 
     RangeUpsamplingGpu range_upsampling(num_range_bins, data_set.num_pulses);
 
-    SarBpGpu bp(num_range_bins);
+    SarBpGpu bp(num_range_bins, data_set.num_pulses);
 
     const int num_pulses = data_set.num_pulses;
     const int num_freq = data_set.num_freq;

--- a/src/sar_bp_gpu.h
+++ b/src/sar_bp_gpu.h
@@ -14,7 +14,11 @@ class SarBpGpu {
     SarBpGpu(const SarBpGpu &) = delete;
     SarBpGpu &operator=(const SarBpGpu &) = delete;
 
-    SarBpGpu(int num_range_bins);
+    // max_num_pulses is the maximum number of pulses for which Backproject()
+    // will be called; it is used to size a work buffer. A caller can integrate
+    // more than max_num_pulses with multiple calls to Backproject(), each
+    // having at most max_num_pulses pulses.
+    SarBpGpu(int num_range_bins, int max_num_pulses);
     ~SarBpGpu();
 
     // Backproject num_pulses x m_num_range_bins pulses from dev_range_profiles
@@ -32,9 +36,11 @@ class SarBpGpu {
 
   private:
     int m_num_range_bins;
+    int m_max_num_pulses;
 
     // Device buffers
     uint8_t *m_dev_workbuf{nullptr};
+    double *m_dev_range_to_center{nullptr};
 };
 
 #endif // _SAR_BP_GPU_H_

--- a/src/sar_ui.cpp
+++ b/src/sar_ui.cpp
@@ -149,11 +149,14 @@ void SarUI::KernelSelectionCallback(Fl_Widget *widget) {
     case static_cast<uintptr_t>(SarGpuKernel::MixedPrecision):
         SetSelectedKernel(SarGpuKernel::MixedPrecision);
         break;
-    case static_cast<uintptr_t>(SarGpuKernel::SmemRange):
-        SetSelectedKernel(SarGpuKernel::SmemRange);
-        break;
     case static_cast<uintptr_t>(SarGpuKernel::IncrPhaseLookup):
         SetSelectedKernel(SarGpuKernel::IncrPhaseLookup);
+        break;
+    case static_cast<uintptr_t>(SarGpuKernel::NewtonRaphsonTwoIter):
+        SetSelectedKernel(SarGpuKernel::NewtonRaphsonTwoIter);
+        break;
+    case static_cast<uintptr_t>(SarGpuKernel::IncrRangeSmem):
+        SetSelectedKernel(SarGpuKernel::IncrRangeSmem);
         break;
     case static_cast<uintptr_t>(SarGpuKernel::SinglePrecision):
         SetSelectedKernel(SarGpuKernel::SinglePrecision);
@@ -174,7 +177,6 @@ void SarUI::Close() {
     m_lock.unlock();
     Fl::awake();
 }
-
 SarUI::SarUI(int width, int height) : m_width(width), m_height(height) {
     m_window.reset(
         new Fl_Double_Window(m_width, m_height + m_menu_height, "Video SAR"));
@@ -191,9 +193,10 @@ SarUI::SarUI(int width, int height) : m_width(width), m_height(height) {
     m_kernel_ref_ind =
         m_kernel_menu->add("FP64 (Reference)", 0, kernel_cb, this);
     m_kernel_menu->add("Mixed Precision (Opt1)", 0, kernel_cb, this);
-    m_kernel_menu->add("Smem Range (Opt2)", 0, kernel_cb, this);
-    m_kernel_menu->add("IncrPhaseLookup (Opt3)", 0, kernel_cb, this);
-    m_kernel_menu->add("SinglePrecision (Opt4)", 0, kernel_cb, this);
+    m_kernel_menu->add("IncrPhaseLookup (Opt2)", 0, kernel_cb, this);
+    m_kernel_menu->add("Newton-Raphson 2 Iter (Opt3)", 0, kernel_cb, this);
+    m_kernel_menu->add("IncrRangeSmem (Opt4)", 0, kernel_cb, this);
+    m_kernel_menu->add("SinglePrecision (Opt5)", 0, kernel_cb, this);
     m_kernel_menu->value(m_kernel_ref_ind);
     m_menu_group->resizable(nullptr);
     m_menu_group->end();

--- a/src/video_sar.cpp
+++ b/src/video_sar.cpp
@@ -98,7 +98,7 @@ void VideoSar::InitCudaBuffers() {
 
     cudaChecked(cudaStreamCreate(&m_stream));
 
-    m_bp.reset(new SarBpGpu(m_num_upsampled_bins));
+    m_bp.reset(new SarBpGpu(m_num_upsampled_bins, n_pulses));
     m_range_upsampling.reset(
         new RangeUpsamplingGpu(m_num_upsampled_bins, n_pulses));
 }


### PR DESCRIPTION
Previously, the SmemRange kernel introduced both shared memory pre-calculations and Newton-Raphson range updates in a single kernel and did so before introducing the incremental phase calculations. This commit splits the SmemRange and Newton-Raphson feature introductions into two separate kernels and introduces them after the incremental phase calculations.