### PR TITLE
Add texture sampling based BP kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
 message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xptxas -v -Xcompiler=-Wall -Xcompiler=-Wextra -Xcompiler=-Werror -Xptxas -lineinfo")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xptxas -v -Xcompiler=-Wall -Xcompiler=-Wextra -Xcompiler=-Werror -lineinfo")
 set(COMMON_CXX_FLAGS "-Wall -Wextra -Wswitch-enum -Werror -flto")
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O1 ${COMMON_CXX_FLAGS}")

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -25,6 +25,8 @@ SarGpuKernel IntToSarGpuKernel(int kernel) {
         return SarGpuKernel::NewtonRaphsonTwoIter;
     case static_cast<int>(SarGpuKernel::IncrRangeSmem):
         return SarGpuKernel::IncrRangeSmem;
+    case static_cast<int>(SarGpuKernel::TextureSampling):
+        return SarGpuKernel::TextureSampling;
     case static_cast<int>(SarGpuKernel::SinglePrecision):
         return SarGpuKernel::SinglePrecision;
     default:

--- a/src/common.h
+++ b/src/common.h
@@ -12,7 +12,8 @@ enum class SarGpuKernel {
     IncrPhaseLookup,
     NewtonRaphsonTwoIter,
     IncrRangeSmem,
-    SinglePrecision
+    TextureSampling,
+    SinglePrecision,
 };
 
 enum class SarReturnCode { Success = 0, InvalidArg, DataReadError };

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -22,6 +22,12 @@
         ptr = nullptr;                                                         \
     }
 
+#define FREE_AND_NULL_CUDA_DEVARRAY_ALLOC(ptr)                                 \
+    if (ptr) {                                                                 \
+        cudaFreeArray(ptr);                                                    \
+        ptr = nullptr;                                                         \
+    }
+
 #define FREE_AND_ZERO_CUFFT_HANDLE(handle)                                     \
     if (handle) {                                                              \
         cufftDestroy(handle);                                                  \

--- a/src/kernels.h
+++ b/src/kernels.h
@@ -8,15 +8,15 @@
 void FftShiftGpu(cuComplex *data, int num_samples, int num_arrays,
                  cudaStream_t stream);
 
-size_t GetMaxBackprojWorkBufSizeBytes(int num_range_bins);
-
-void ComputeRangeToCenterWrapper(double *dev_range_to_center,
-                                 const float3 *dev_ant_pos, int num_pulses,
-                                 cudaStream_t stream);
+// max_num_pulses is the maximum number of pulses for which SarBpGpuWrapper
+// will be invoked. Pulse counts larger than max_num_pulses can be accommodated
+// by multiple calls to SarBpGpuWrapper, each with no more than max_num_pulses
+// pulses
+size_t GetMaxBackprojWorkBufSizeBytes(int num_range_bins, int max_num_pulses);
 
 void SarBpGpuWrapper(cuComplex *image, int image_width, int image_height,
-                     const cuComplex *range_profiles,
-                     const double *range_to_center, uint8_t *bp_workbuf,
+                     cudaTextureObject_t tex_obj,
+                     const cuComplex *range_profiles, uint8_t *bp_workbuf,
                      int num_range_bins, int num_pulses, const float3 *ant_pos,
                      double freq_min, double dr, double dx, double dy,
                      double z0, SarGpuKernel selected_kernel,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,6 +123,7 @@ static void runGpu(std::vector<cuComplex> &image, const ReconParams &params,
     }
 
     cudaChecked(cudaSetDevice(device_id));
+    LOG("Using device ID %d\n", device_id);
 
     Gotcha::Reader reader(params.gotcha_dir);
     const SarReturnCode rc = reader.ReadDataSet(data_set, request);

--- a/src/sar_bp_gpu.cpp
+++ b/src/sar_bp_gpu.cpp
@@ -3,17 +3,58 @@
 #include "kernels.h"
 
 #include <chrono>
+#include <cstring>
 
 SarBpGpu::SarBpGpu(int num_range_bins, int max_num_pulses)
     : m_num_range_bins(num_range_bins), m_max_num_pulses(max_num_pulses) {
     const size_t bp_workbuf_size_bytes =
-        GetMaxBackprojWorkBufSizeBytes(m_num_range_bins);
+        GetMaxBackprojWorkBufSizeBytes(m_num_range_bins, max_num_pulses);
     cudaChecked(cudaMalloc((void **)&m_dev_workbuf, bp_workbuf_size_bytes));
-    cudaChecked(cudaMalloc((void **)&m_dev_range_to_center,
-                           sizeof(double) * m_max_num_pulses));
+
+    cudaChannelFormatDesc channel_desc =
+        cudaCreateChannelDesc(32, 32, 0, 0, cudaChannelFormatKindFloat);
+    cudaChecked(cudaMallocArray(&m_dev_tex_array, &channel_desc,
+                                m_num_range_bins, max_num_pulses));
+
+    struct cudaResourceDesc res_desc;
+    memset(&res_desc, 0, sizeof(res_desc));
+    res_desc.resType = cudaResourceTypeArray;
+    res_desc.res.array.array = m_dev_tex_array;
+
+    struct cudaTextureDesc tex_desc;
+    memset(&tex_desc, 0, sizeof(tex_desc));
+    tex_desc.addressMode[0] = cudaAddressModeBorder;
+    tex_desc.addressMode[1] = cudaAddressModeBorder;
+    tex_desc.filterMode = cudaFilterModeLinear;
+    tex_desc.normalizedCoords = 0;
+    tex_desc.readMode = cudaReadModeElementType;
+
+    cudaChecked(
+        cudaCreateTextureObject(&m_tex_obj, &res_desc, &tex_desc, NULL));
 }
 
-SarBpGpu::~SarBpGpu() { FREE_AND_NULL_CUDA_DEV_ALLOC(m_dev_workbuf); }
+SarBpGpu::~SarBpGpu() {
+    FREE_AND_NULL_CUDA_DEV_ALLOC(m_dev_workbuf);
+    FREE_AND_NULL_CUDA_DEVARRAY_ALLOC(m_dev_tex_array);
+    cudaDestroyTextureObject(m_tex_obj);
+    m_tex_obj = 0;
+}
+
+bool SarBpGpu::KernelUsesTextureMemory(SarGpuKernel kernel) {
+    switch (kernel) {
+    case SarGpuKernel::Invalid:
+    case SarGpuKernel::DoublePrecision:
+    case SarGpuKernel::MixedPrecision:
+    case SarGpuKernel::IncrPhaseLookup:
+    case SarGpuKernel::NewtonRaphsonTwoIter:
+    case SarGpuKernel::IncrRangeSmem:
+    case SarGpuKernel::SinglePrecision:
+        return false;
+    case SarGpuKernel::TextureSampling:
+        return true;
+    }
+    return false;
+}
 
 void SarBpGpu::Backproject(cuComplex *dev_image,
                            const cuComplex *dev_range_profiles,
@@ -27,19 +68,27 @@ void SarBpGpu::Backproject(cuComplex *dev_image,
     const double dr = max_wr / m_num_range_bins;
 
     int num_pulses_processed = 0;
+    const bool use_texture = KernelUsesTextureMemory(kernel);
     while (num_pulses_processed < num_pulses) {
         const int num_pulses_this_block =
             std::min(num_pulses, m_max_num_pulses);
-        ComputeRangeToCenterWrapper(m_dev_range_to_center,
-                                    dev_ant_pos + num_pulses_processed,
-                                    num_pulses_this_block, stream);
-        cudaChecked(cudaGetLastError());
-        SarBpGpuWrapper(
-            dev_image, image_width, image_height,
-            dev_range_profiles + num_pulses_processed * m_num_range_bins,
-            m_dev_range_to_center, m_dev_workbuf, m_num_range_bins,
-            num_pulses_this_block, dev_ant_pos + num_pulses_processed, min_freq,
-            dr, dx, dy, 0.0f, kernel, stream);
+
+        if (use_texture) {
+            cudaChecked(cudaMemcpy2DToArrayAsync(
+                m_dev_tex_array, 0, 0,
+                dev_range_profiles + num_pulses_processed * m_num_range_bins,
+                sizeof(cuComplex) * m_num_range_bins,
+                sizeof(cuComplex) * m_num_range_bins, num_pulses_this_block,
+                cudaMemcpyDeviceToDevice, stream));
+            cudaChecked(cudaGetLastError());
+        }
+
+        SarBpGpuWrapper(dev_image, image_width, image_height, m_tex_obj,
+                        dev_range_profiles +
+                            num_pulses_processed * m_num_range_bins,
+                        m_dev_workbuf, m_num_range_bins, num_pulses_this_block,
+                        dev_ant_pos + num_pulses_processed, min_freq, dr, dx,
+                        dy, 0.0f, kernel, stream);
         cudaChecked(cudaGetLastError());
         num_pulses_processed += num_pulses_this_block;
     }

--- a/src/sar_bp_gpu.h
+++ b/src/sar_bp_gpu.h
@@ -35,12 +35,15 @@ class SarBpGpu {
                      cudaStream_t stream);
 
   private:
+    bool KernelUsesTextureMemory(SarGpuKernel kernel);
+
     int m_num_range_bins;
     int m_max_num_pulses;
 
     // Device buffers
     uint8_t *m_dev_workbuf{nullptr};
-    double *m_dev_range_to_center{nullptr};
+    cudaArray *m_dev_tex_array{nullptr};
+    cudaTextureObject_t m_tex_obj{0};
 };
 
 #endif // _SAR_BP_GPU_H_

--- a/src/sar_ui.cpp
+++ b/src/sar_ui.cpp
@@ -158,6 +158,9 @@ void SarUI::KernelSelectionCallback(Fl_Widget *widget) {
     case static_cast<uintptr_t>(SarGpuKernel::IncrRangeSmem):
         SetSelectedKernel(SarGpuKernel::IncrRangeSmem);
         break;
+    case static_cast<uintptr_t>(SarGpuKernel::TextureSampling):
+        SetSelectedKernel(SarGpuKernel::TextureSampling);
+        break;
     case static_cast<uintptr_t>(SarGpuKernel::SinglePrecision):
         SetSelectedKernel(SarGpuKernel::SinglePrecision);
         break;
@@ -196,7 +199,8 @@ SarUI::SarUI(int width, int height) : m_width(width), m_height(height) {
     m_kernel_menu->add("IncrPhaseLookup (Opt2)", 0, kernel_cb, this);
     m_kernel_menu->add("Newton-Raphson 2 Iter (Opt3)", 0, kernel_cb, this);
     m_kernel_menu->add("IncrRangeSmem (Opt4)", 0, kernel_cb, this);
-    m_kernel_menu->add("SinglePrecision (Opt5)", 0, kernel_cb, this);
+    m_kernel_menu->add("TextureSampling (Opt5)", 0, kernel_cb, this);
+    m_kernel_menu->add("SinglePrecision (Opt6)", 0, kernel_cb, this);
     m_kernel_menu->value(m_kernel_ref_ind);
     m_menu_group->resizable(nullptr);
     m_menu_group->end();


### PR DESCRIPTION
Add a high precision-kernel that utilizes texture sampling for interpolating the range profile data. This kernel does not increase performance in its current form as the kernel is already heavily fp64 compute bound.

Signed-off-by: Thomas Benson <tbensongit@gmail.com>