### PR TITLE
Add Single File Format (SFF) to ease testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-# CMake version 3.23 is needed to default to native CUDA architectures (i.e.
+# CMake version 3.24 is needed to default to native CUDA architectures (i.e.
 # architectures for the GPUs installed on the build system). The minimum can be
 # reduced to CMake 3.18 if the user sets the environment variable CUDAARCHS="XY" for
 # their desired architecture XY (e.g. 86 for compute capability 8.6).
-cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(sarbp LANGUAGES CUDA CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you would like to discuss the project, please contact the author (Thomas Bens
 
 # Dependencies and Requirements
 
-Dependencies include CMake (3.23+), CUDA, Boost (only the `program_options` library), and FLTK. Note that an NVIDIA GPU is required to run the GPU-based backprojectors (including the video SAR mode). To date, this code has been developed on Ubuntu 22.04 with CUDA 12, although other reasonably new Linux distributions should work as well. For Ubuntu, new versions of CMake are available via Kitware's APT repository (https://apt.kitware.com). The new vesion of CMake is only required to default to building the CUDA kernels for the GPUs installed on the system where the software is being built. The architecture can also be specified explicitly using e.g. `CUDAARCHS=86 make` to build for compute capability 8.6. In that case, the CMake minimum version can be dropped to 3.18.
+Dependencies include CMake (3.24+), CUDA, Boost (only the `program_options` library), and FLTK. Note that an NVIDIA GPU is required to run the GPU-based backprojectors (including the video SAR mode). To date, this code has been developed on Ubuntu 22.04 with CUDA 12, although other reasonably new Linux distributions should work as well. For Ubuntu, new versions of CMake are available via Kitware's APT repository (https://apt.kitware.com). The new vesion of CMake is only required to default to building the CUDA kernels for the GPUs installed on the system where the software is being built. The architecture can also be specified explicitly using e.g. `CUDAARCHS=86 make` to build for compute capability 8.6. In that case, the CMake minimum version can be dropped to 3.18.
 
 # Building the Code
 
@@ -94,15 +94,15 @@ There are currently six kernels (i.e. `--kern 1` through `--kern 6`). Briefly, t
 
 The performance metric computed by the code is giga backprojections per second (GBP/s). A single backprojection includes the calculations to accumulate the contributions from a single pixel in a single pulse. With an N by N image and P pulses, there are thus `N*N*P` total backprojection operations.
 
-| Kernel  | SER (dB) | GBP/s Titan RTX | GBP/s RTX 3060 |
-| ------------- | ------------- | ------------- | ------------- |
-| 1 (FP64) | ~126 | 3.88 | 1.58 |
-| 2 (Mixed) | ~78 | 5.41 | 2.06 |
-| 3 (Incr Phase Calcs) | ~83 | 9.12 | 3.53 |
-| 4 (Newton-Raphson) | ~82 | 10.69 | 4.15 |
-| 5 (Smem Range Calcs) | ~81 | 15.22 | 6.08 |
-| 6 (Texture Sampling) | ~73 | 15.10 | 5.97 |
-| 7 (Single Precision) | ~15 | 80.76 | 71.8 |
+| Kernel               | SER (dB) | GBP/s Titan RTX | GBP/s RTX 3060 |
+| -------------------- | -------- | --------------- | -------------- |
+| 1 (FP64)             | ~126     | 3.88            | 1.58           |
+| 2 (Mixed)            | ~78      | 5.41            | 2.06           |
+| 3 (Incr Phase Calcs) | ~83      | 9.12            | 3.53           |
+| 4 (Newton-Raphson)   | ~82      | 10.69           | 4.15           |
+| 5 (Smem Range Calcs) | ~81      | 15.22           | 6.08           |
+| 6 (Texture Sampling) | ~73      | 15.10           | 5.97           |
+| 7 (Single Precision) | ~15      | 80.76           | 71.8           |
 
 The Titan RTX has 1/32nd double precision throughput relative to single precision throughput whereas the RTX 3060 has 1/64th FP64 relative to FP32. The Titan RTX thus has ~1.3x and ~2.6x higher FP32 and FP64 throughput, respectively, relative to the 3060. The higher FP64 performance of the Titan RTX is very noticeable in all of the kernels that involve FP64 calculations, but the single precision kernel is closer to parity between the two GPUs.
 

--- a/src/data_reader.h
+++ b/src/data_reader.h
@@ -63,4 +63,40 @@ class Reader {
 
 } // namespace Gotcha
 
+// Data stored in a Single File Format (SFF). This is a simple file format
+// primarily intended to ease testing.
+namespace SFF {
+// SFF consists of data in the following order and format:
+// (1) The header below,
+// (2) num_pulses pulses, each with num_freq samples, using two FP32 values
+// (I/Q) per sample
+// (3) num_pulses antenna positions, each with 3 coordinates
+// (x,y,z) in FP32 format All of the fields are in little endian format.
+struct Header {
+    uint32_t num_pulses;
+    uint32_t num_freq;
+    float del_freq;
+    float min_freq;
+    uint32_t flags;
+    uint32_t pad[3]; // pad header to 32 bytes
+};
+
+enum class Flags {
+    // Set if the output file has data for the pulses. A file that only includes
+    // a header and antenna positions will have the data populated via a seeded
+    // random number generator on read. This provides a useful way for
+    // performance
+    // testing without requiring large files.
+    FileHasData = 0x1
+};
+
+// Write a dataset represented as a Gotcha::DataBlock into an SFF output file.
+// If skip_data is true, then only the header and antenna positions will be
+// written and the header will have the SFF::Flags::FileHasData flag set to
+// false.
+void WriteDatasetAsSFF(const char *filename, const Gotcha::DataBlock &data,
+                       bool skip_data = false);
+void ReadDataset(Gotcha::DataBlock &data, const char *filename);
+} // namespace SFF
+
 #endif /* _DATA_READER_H_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,7 @@ static void runGpu(std::vector<cuComplex> &image, const ReconParams &params,
     }
 
     cudaChecked(cudaSetDevice(device_id));
-    LOG("Using device ID %d\n", device_id);
+    LOG("Using device ID %d", device_id);
 
     Gotcha::Reader reader(params.gotcha_dir);
     const SarReturnCode rc = reader.ReadDataSet(data_set, request);


### PR DESCRIPTION
Add a simple file format that stores all of the input data in a single file. This allows either simpler testing with the GOTCHA data (by converting a set of files into a single file) or testing with other data. The reader and writer also support a mode that only writes metadata and generates random data on input. This is useful for benchmarking using small input files.

Signed-off-by: Thomas Benson <tbensongit@gmail.com>